### PR TITLE
CORE-963: add more code to have a runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,20 @@ cargo add marc-record
 
 Load, parse and inspect a record:
 ```rust
-let mut contents = Vec::new();
-File::open(path_to_my_file)?.read_to_end(&mut contents)?;
-let records = marc_record::parse_records(&contents)?;
-println!("File contains {} records", records.len());
+use std::fs::File;
+use std::io::Read;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut contents = Vec::new();
+    File::open("./record.mrc")?.read_to_end(&mut contents)?;
+    let records = marc_record::parse_records(&contents)?;
+    println!("File contains {} records", records.len());
+    let record1 = &records[0];
+    for field in record1.fields.iter() {
+        println!("Field: {:?}", field);
+    }
+    Ok(())
+}
 ```
 
 License


### PR DESCRIPTION
CORE-963

# What
When trying the example code, I spent a bit of time making it run. Rust being Rust, I thought it would make it easier if the example was a complete program.
