### PR TITLE
task: fix typo with enum MultipartResourceRecordLevel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ pub enum MultipartResourceRecordLevel {
     NotApplicable,
     Set,
     PartWithIndependentTitle,
-    PartwithDependentTitle,
+    PartWithDependentTitle,
 }
 
 enum Decoder {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -283,7 +283,7 @@ fn parse_multipart_resource_record_level(
         ' ' => Ok(MultipartResourceRecordLevel::NotApplicable),
         'a' => Ok(MultipartResourceRecordLevel::Set),
         'b' => Ok(MultipartResourceRecordLevel::PartWithIndependentTitle),
-        'c' => Ok(MultipartResourceRecordLevel::PartwithDependentTitle),
+        'c' => Ok(MultipartResourceRecordLevel::PartWithDependentTitle),
 
         _ => fail(input),
     }


### PR DESCRIPTION
# What
While working on marc-record-ex, I noticed a slight inconsistency with an enum arm.